### PR TITLE
Initial abstract for fpm on FortranCon2021

### DIFF
--- a/FortranCon2021-fpm/README.md
+++ b/FortranCon2021-fpm/README.md
@@ -35,7 +35,7 @@ Fortran package manager
 With the Fortran package manager (fpm) we are building the foundation of a new ecosystem for Fortran libraries and projects.
 The main goal of fpm is to create a reliable and productive tool and improve the user experience for Fortran programmers. 
 It provides an easy-to-use way to build applications and use libraries, making it especially easy to reuse projects as dependencies.
-Fpm takes care of fetching and building all transient dependencies used compiling the main project.
+Fpm takes care of fetching and building all transitive dependencies used to compile the main project.
 An intuitive command-line interface is available to run, test, and install Fortran projects on any platform.
 Support for all major Fortran compilers and platforms is readily available and community agreed-on default settings for all compilers are available.
 

--- a/FortranCon2021-fpm/README.md
+++ b/FortranCon2021-fpm/README.md
@@ -32,10 +32,10 @@ Fortran package manager
 
 ## Abstract
 
-With the Fortran package manager (fpm) we are building the foundation of a new ecosystem for Fortran libraries and projects.
-The main goal of fpm is to create a reliable and productive tool and improve the user experience for Fortran programmers. 
-It provides an easy-to-use way to build applications and use libraries, making it especially easy to reuse projects as dependencies.
-Fpm takes care of fetching and building all transitive dependencies used to compile the main project.
+A language-specific package manager is an important element to build an efficient ecosystem of libraries and projects.
+Fortran has long missed a dedicated package manager, making the user experience of practitioners cumbersome.
+With the Fortran package manager (fpm) we are addressing these needs creating a reliable and productive tool that makes building applications and using libraries intuitive.
+Fpm takes care of fetching and building all transitive dependencies used to build the main project making especially easy to reuse other projects.
 An intuitive command-line interface is available to run, test, and install Fortran projects on any platform.
 Support for all major Fortran compilers and platforms is readily available and community agreed-on default settings for all compilers are available.
 

--- a/FortranCon2021-fpm/README.md
+++ b/FortranCon2021-fpm/README.md
@@ -3,20 +3,13 @@
 ## Authors
 
 - [Sebastian Ehlert](https://github.com/awvwgk)
-- [Ondřej Čertík](https://github.com/certik)
 - [Milan Curcic](https://github.com/milancurcic)
-- [Philipp Engel](https://github.com/interkosmos)
 - [Jakub Jelínek](https://github.com/kubajj)
 - [Laurence Kedward](https://github.com/lkedward)
-- [Vincent Magnin](https://github.com/vmagnin)
-- [Arjen Markus](https://github.com/arjenmarkus)
+- [Vincent Magnin](https://github.com/vmagnin
 - [Emanuele Pagone](https://github.com/epagone)
-- [Ivan Pribec](https://github.com/ivan-pi)
 - [Brad Richardson](https://github.com/everythingfunctional)
-- [Damian Rouson](https://github.com/rouson)
-- [Carlos Une](https://github.com/brocolis)
 - [John Urban](https://github.com/urbanjost)
-- [Mark Wieczorek](https://github.com/MarkWieczorek)
 
 ## Track
 
@@ -33,13 +26,12 @@ Fortran package manager
 ## Abstract
 
 A language-specific package manager is an important element to build an efficient ecosystem of libraries and projects.
-Fortran has long missed a dedicated package manager, making the user experience of practitioners cumbersome.
-With the Fortran package manager (fpm) we are addressing these needs creating a reliable and productive tool that makes building applications and using libraries intuitive.
+Fortran has long missed a dedicated package manager, making the user experience of practitioners cumbersome. With the Fortran package manager (fpm) we are addressing these needs creating a reliable and productive tool that makes building applications and using libraries intuitive.
 Fpm takes care of fetching and building all transitive dependencies used to build the main project making especially easy to reuse other projects.
 As a cross-platform reproducable development and production environment fpm simplifies the difficulties in building, running, testing, and installing Fortran-centric projects.
-Support for all major Fortran compilers and platforms is readily available and community agreed-on default settings for all compilers are available.
+Support for all major Fortran compilers and platforms is available.
 
 Fpm is written in Fortran and built with itself, making it easy to bootstrap and install fpm on any platform with a Fortran compiler.
 The positive effect of a Fortran implementation is the easy accessibility of the codebase, which enables the community to contribute back and improve fpm further.
-While fpm is relatively new and still rapidly developing, it already found adoption even for large-scale projects with several hundred to thousand of Fortran source files today.
-Features to incorporate build requirements emerging from developing parallel applications, like OpenMP, coarrays, MPI, GPUs, or integrations with GUI environments are planned or under active development.
+While fpm is relatively new and still rapidly developing, it already found adoption even for large-scale projects today.
+Features to incorporate build requirements emerging from developing parallel applications or integrations with GUI environments are planned or under active development.

--- a/FortranCon2021-fpm/README.md
+++ b/FortranCon2021-fpm/README.md
@@ -6,7 +6,7 @@
 - [Milan Curcic](https://github.com/milancurcic)
 - [Jakub Jelínek](https://github.com/kubajj)
 - [Laurence Kedward](https://github.com/lkedward)
-- [Vincent Magnin](https://github.com/vmagnin
+- [Vincent Magnin](https://github.com/vmagnin)
 - [Emanuele Pagone](https://github.com/epagone)
 - [Brad Richardson](https://github.com/everythingfunctional)
 - [John Urban](https://github.com/urbanjost)

--- a/FortranCon2021-fpm/README.md
+++ b/FortranCon2021-fpm/README.md
@@ -36,10 +36,10 @@ A language-specific package manager is an important element to build an efficien
 Fortran has long missed a dedicated package manager, making the user experience of practitioners cumbersome.
 With the Fortran package manager (fpm) we are addressing these needs creating a reliable and productive tool that makes building applications and using libraries intuitive.
 Fpm takes care of fetching and building all transitive dependencies used to build the main project making especially easy to reuse other projects.
-An intuitive command-line interface is available to run, test, and install Fortran projects on any platform.
+As a cross-platform reproducable development and production environment fpm simplifies the difficulties in building, running, testing, and installing Fortran-centric projects.
 Support for all major Fortran compilers and platforms is readily available and community agreed-on default settings for all compilers are available.
 
 Fpm is written in Fortran and built with itself, making it easy to bootstrap and install fpm on any platform with a Fortran compiler.
 The positive effect of a Fortran implementation is the easy accessibility of the codebase, which enables the community to contribute back and improve fpm further.
-Fpm already found adoption even for large-scale projects with several hundred to thousand of Fortran source files today.
-After one year of development of fpm's Fortran implementation, it is already available in distributions like conda-forge, homebrew, or msys2.
+While fpm is relatively new and still rapidly developing, it already found adoption even for large-scale projects with several hundred to thousand of Fortran source files today.
+Features to incorporate build requirements emerging from developing parallel applications, like OpenMP, coarrays, MPI, GPUs, or integrations with GUI environments are planned or under active development.

--- a/FortranCon2021-fpm/README.md
+++ b/FortranCon2021-fpm/README.md
@@ -1,0 +1,45 @@
+# FortranCon2021: fpm
+
+## Authors
+
+- [Sebastian Ehlert](https://github.com/awvwgk)
+- [Ondřej Čertík](https://github.com/certik)
+- [Milan Curcic](https://github.com/milancurcic)
+- [Philipp Engel](https://github.com/interkosmos)
+- [Jakub Jelínek](https://github.com/kubajj)
+- [Laurence Kedward](https://github.com/lkedward)
+- [Vincent Magnin](https://github.com/vmagnin)
+- [Arjen Markus](https://github.com/arjenmarkus)
+- [Emanuele Pagone](https://github.com/epagone)
+- [Ivan Pribec](https://github.com/ivan-pi)
+- [Brad Richardson](https://github.com/everythingfunctional)
+- [Damian Rouson](https://github.com/rouson)
+- [Carlos Une](https://github.com/brocolis)
+- [John Urban](https://github.com/urbanjost)
+- [Mark Wieczorek](https://github.com/MarkWieczorek)
+
+## Track
+
+Fortran-lang minisymposium (12 + 3 minutes discussion)
+
+## Presenter
+
+[Sebastian Ehlert](https://github.com/awvwgk)
+
+## Title:
+
+Fortran package manager
+
+## Abstract
+
+With the Fortran package manager (fpm) we are building the foundation of a new ecosystem for Fortran libraries and projects.
+The main goal of fpm is to create a reliable and productive tool and improve the user experience for Fortran programmers. 
+It provides an easy-to-use way to build applications and use libraries, making it especially easy to reuse projects as dependencies.
+Fpm takes care of fetching and building all transient dependencies used compiling the main project.
+An intuitive command-line interface is available to run, test, and install Fortran projects on any platform.
+Support for all major Fortran compilers and platforms is readily available and community agreed-on default settings for all compilers are available.
+
+Fpm is written in Fortran and built with itself, making it easy to bootstrap and install fpm on any platform with a Fortran compiler.
+The positive effect of a Fortran implementation is the easy accessibility of the codebase, which enables the community to contribute back and improve fpm further.
+Fpm already found adoption even for large-scale projects with several hundred to thousand of Fortran source files today.
+After one year of development of fpm's Fortran implementation, it is already available in distributions like conda-forge, homebrew, or msys2.


### PR DESCRIPTION
Here is the first draft for the abstract of the fpm presentation in the Fortran-lang minisymposium at the FortranCon2021.

I added everybody who was active at the fpm repository in the discussion or implementation of features recently:

@certik, @milancurcic, @interkosmos, @kubajj, @lkedward, @vmagnin, @arjenmarkus, @epagone, @ivan-pi, @everythingfunctional, @rouson, @brocolis, @urbanjost, @MarkWieczorek

Here are a few thing to check:

- Please confirm that you would like to be an author here. Authorship on this talk will be *opt-in*, therefore, please comment until the first abstract submission deadline on the 31st July here.
- Please comment if I you think I have omitted any contributors from the last year!

Thematically we want to focus on:

1. The motivation behind fpm
2. Why we chose to implement fpm in Fortran
3. New features in fpm and the general adoption in the community
4. Future roadmaps (where we want to be next FortranCon?)