### PR TITLE
Add abstract for PackagingCon 2021

### DIFF
--- a/PackagingCon2021-fpm/README.md
+++ b/PackagingCon2021-fpm/README.md
@@ -3,6 +3,7 @@
 ## Authors
 
 - [Sebastian Ehlert](https://github.com/awvwgk)
+- [Ondřej Čertík](https://github.com/certik)
 - [Milan Curcic](https://github.com/milancurcic)
 - [Jakub Jelínek](https://github.com/kubajj)
 - [Laurence Kedward](https://github.com/lkedward)

--- a/PackagingCon2021-fpm/README.md
+++ b/PackagingCon2021-fpm/README.md
@@ -1,0 +1,36 @@
+# PackagingCon2021: fpm
+
+## Authors
+
+- [Sebastian Ehlert](https://github.com/awvwgk)
+- [Milan Curcic](https://github.com/milancurcic)
+- [Jakub Jelínek](https://github.com/kubajj)
+- [Laurence Kedward](https://github.com/lkedward)
+- [Vincent Magnin](https://github.com/vmagnin)
+- [Emanuele Pagone](https://github.com/epagone)
+- [Brad Richardson](https://github.com/everythingfunctional)
+- [John Urban](https://github.com/urbanjost)
+
+## Presenter
+
+[Sebastian Ehlert](https://github.com/awvwgk)
+
+## Title:
+
+Fortran Package Manager: Toward a rich ecosystem of Fortran packages
+
+## Abstract
+
+Fortran is the oldest programming language still in use today, targeting high-performance scientific and engineering applications.
+Traditionally, Fortran software has used build systems that are not portable or are difficult to use or extend.
+This has presented a significant barrier to entry for users, and has made it difficult to use libraries as dependencies, or distribute your own library for use in other projects.
+Fortran Package Manager (fpm) is a new language-specific package manager and build system.
+Inspired by Rust's Cargo, fpm's key goals are to improve the user experience and nurture the growth of a rich ecosystem of Fortran libraries.
+
+Fpm assumes sane defaults so that most users can enjoy a zero-configuration experience, while providing options to customize behavior.
+Fpm can scaffold a new Fortran project, fetch and build remote dependencies, and run tests and project executables.
+It is implemented in pure Fortran and can bootstrap itself.
+It supports multiple compilers, and runs on all major operating systems.
+Fpm also supports a flexible plugin system that makes it easy for users to extend its functionality.
+While new and rapidly developing, it's already used as a build system for large projects and has been met with an overwhelming response from the Fortran community.
+In this talk, we'll discuss the progress made so far, technical challenges that are specific to building Fortran projects, and next steps.

--- a/PackagingCon2021-fpm/README.md
+++ b/PackagingCon2021-fpm/README.md
@@ -25,12 +25,10 @@ Fortran is the oldest programming language still in use today, targeting high-pe
 Traditionally, Fortran software has used build systems that are not portable or are difficult to use or extend.
 This has presented a significant barrier to entry for users, and has made it difficult to use libraries as dependencies, or distribute your own library for use in other projects.
 Fortran Package Manager (fpm) is a new language-specific package manager and build system.
-Inspired by Rust's Cargo, fpm's key goals are to improve the user experience and nurture the growth of a rich ecosystem of Fortran libraries.
+The key goals are to improve the user experience and nurture the growth of a rich ecosystem of Fortran libraries.
 
 Fpm assumes sane defaults so that most users can enjoy a zero-configuration experience, while providing options to customize behavior.
 Fpm can scaffold a new Fortran project, fetch and build remote dependencies, and run tests and project executables.
-It is implemented in pure Fortran and can bootstrap itself.
-It supports multiple compilers, and runs on all major operating systems.
-Fpm also supports a flexible plugin system that makes it easy for users to extend its functionality.
-While new and rapidly developing, it's already used as a build system for large projects and has been met with an overwhelming response from the Fortran community.
-In this talk, we'll discuss the progress made so far, technical challenges that are specific to building Fortran projects, and next steps.
+It supports multiple compilers, runs on all major operating systems and can bootstrap itself.
+While new and rapidly developing, it is already used as a build system for large projects and has been met with an overwhelming response from the Fortran community.
+We want to discuss technical challenges that are specific to building Fortran projects and further next steps.


### PR DESCRIPTION
See https://fortran-lang.discourse.group/t/1581

Now that we are starting to explore how fpm can integrate with existing packaging ecosystems this might be a good opportunity to present fpm at the PackagingCon 2021.

@milancurcic, @kubajj, @LKedward, @vmagnin, @epagone, @everythingfunctional, @urbanjost: I included you already as authors since we will very likely reuse parts of the FortranCon 2021 presentation here.

Thanks to Milan for the abstract.

We currently have ~225 words, but the limit are 200, we have to shorten it a bit. Submission deadline is 3rd Sep, 23:59 UTC-12:00. Kinda strange time, but since this is soon, I'll go ahead and send the abstract soon.